### PR TITLE
chore: refactor org login from environment variable

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           SFDX_AUTH_URL_DEVED: ${{ secrets.SFDX_AUTH_URL_DEVED }}
         run: |
-          sfdx auth:sfdxurl:store -s -a mdapi-issues-deved -f /dev/stdin <<< "${SFDX_AUTH_URL_DEVED}"
+          sfdx auth:sfdxurl:store -s -a mdapi-issues-deved -f <(echo "${SFDX_AUTH_URL_DEVED}")
           yarn test
   scratch-org:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
         env:
           SFDX_AUTH_URL_DEVHUB: ${{ secrets.SFDX_AUTH_URL_DEVHUB }}
         run: |
-          sfdx auth:sfdxurl:store -d -a devhub -f /dev/stdin <<< "${SFDX_AUTH_URL_DEVHUB}"
+          sfdx auth:sfdxurl:store -d -a devhub -f <(echo "${SFDX_AUTH_URL_DEVHUB}")
           yarn develop
           yarn test
       - name: Delete scratch org


### PR DESCRIPTION

Use bash process substitution which makes the input appear as a filename instead of /dev/stdin.
